### PR TITLE
Replace API with Django forms and templates

### DIFF
--- a/books/forms.py
+++ b/books/forms.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+from typing import List
+
+from django import forms
+from django.contrib.auth import get_user_model
+from django.contrib.auth.forms import UserCreationForm
+
+from .models import Book
+
+
+def _split_values(value: str) -> List[str]:
+    if not value:
+        return []
+    parts = [chunk.strip() for chunk in value.replace(";", ",").split(",")]
+    return [chunk for chunk in parts if chunk]
+
+
+class StyledFormMixin:
+    """Apply consistent styling to keep templates lean."""
+
+    field_class = "form-control"
+
+    def _apply_styles(self):
+        for field in self.fields.values():
+            widget = field.widget
+            existing = widget.attrs.get("class", "").strip()
+            if isinstance(widget, (forms.CheckboxInput, forms.CheckboxSelectMultiple)):
+                widget.attrs["class"] = existing or "form-check-input"
+            else:
+                widget.attrs["class"] = f"{existing} {self.field_class}".strip()
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._apply_styles()
+
+
+class BookForm(StyledFormMixin, forms.ModelForm):
+    class Meta:
+        model = Book
+        fields = [
+            "title",
+            "author",
+            "description",
+            "image",
+            "phone_number",
+            "location",
+            "is_active",
+        ]
+        widgets = {
+            "description": forms.Textarea(attrs={"rows": 4}),
+            "is_active": forms.CheckboxInput(attrs={"class": "form-check-input"}),
+        }
+
+
+class BookSearchForm(StyledFormMixin, forms.Form):
+    query = forms.CharField(required=False, label="Keyword")
+    titles = forms.CharField(required=False, label="Titles", help_text="Comma separated")
+    authors = forms.CharField(required=False, label="Authors", help_text="Comma separated")
+
+    def parsed_titles(self) -> List[str]:
+        raw = self.cleaned_data.get("titles", "") if hasattr(self, "cleaned_data") else ""
+        return _split_values(raw)
+
+    def parsed_authors(self) -> List[str]:
+        raw = self.cleaned_data.get("authors", "") if hasattr(self, "cleaned_data") else ""
+        return _split_values(raw)
+
+
+class AIAdviceForm(StyledFormMixin, forms.Form):
+    prompt = forms.CharField(
+        label="How can we help?",
+        widget=forms.Textarea(attrs={"rows": 4, "placeholder": "Describe what kind of book you need..."}),
+    )
+
+
+class SignUpForm(StyledFormMixin, UserCreationForm):
+    email = forms.EmailField(required=False, help_text="Optional, helps other users reach you")
+
+    class Meta(UserCreationForm.Meta):
+        model = get_user_model()
+        fields = ("username", "email")
+
+    def save(self, commit: bool = True):
+        user = super().save(commit=False)
+        user.email = self.cleaned_data.get("email", "")
+        if commit:
+            user.save()
+        return user

--- a/books/templates/books/ai_advice.html
+++ b/books/templates/books/ai_advice.html
@@ -1,0 +1,67 @@
+{% extends "books/base.html" %}
+
+{% block title %}AI book advisor · BookSwap{% endblock %}
+
+{% block content %}
+<div class="card" style="padding: 1.75rem; max-width: 840px; margin: 0 auto 2rem;">
+    <h1 class="section-title">Let our AI librarian help</h1>
+    <p style="color:#52606d;">Describe what you or your friend need. We will suggest themes, books and show matches from the community library.</p>
+    <form method="post" style="margin-top: 1.5rem; display:flex; flex-direction:column; gap:1.5rem;">
+        {% csrf_token %}
+        <div class="field-group">
+            {{ form.prompt.label_tag }}
+            {{ form.prompt }}
+            {% if form.prompt.errors %}
+                {% for error in form.prompt.errors %}
+                    <div style="color:#dc2626; font-size:0.9rem;">{{ error }}</div>
+                {% endfor %}
+            {% endif %}
+        </div>
+        <button type="submit" class="button" style="align-self:flex-start;">Ask for advice</button>
+    </form>
+</div>
+
+{% if ai_data %}
+    <section style="display:grid; gap:1.75rem;">
+        <div class="card" style="padding:1.5rem;">
+            <h2 style="margin-top:0;">AI suggestions</h2>
+            {% if ai_data.suggested_books %}
+                <ul style="padding-left:1rem; line-height:1.7;">
+                    {% for item in ai_data.suggested_books %}
+                        <li><strong>{{ item.title }}</strong>{% if item.author %} by {{ item.author }}{% endif %}{% if item.why %} — {{ item.why }}{% endif %}</li>
+                    {% endfor %}
+                </ul>
+            {% else %}
+                <p style="color:#52606d;">No direct matches yet – try a more detailed prompt.</p>
+            {% endif %}
+        </div>
+
+        <div class="card" style="padding:1.5rem;">
+            <h2 style="margin-top:0;">Books you can swap now</h2>
+            {% if matched_books %}
+                <div class="grid">
+                    {% for book in matched_books %}
+                        <article class="card" style="border-color:#e5e7eb;">
+                            {% if book.image %}
+                                <img src="{{ book.image.url }}" alt="{{ book.title }} cover">
+                            {% endif %}
+                            <div class="card-body">
+                                <h3 class="card-title"><a href="{% url 'books:book-detail' book.pk %}">{{ book.title }}</a></h3>
+                                {% if book.author %}<div style="color:#52606d;">by {{ book.author }}</div>{% endif %}
+                                <div style="font-size:0.95rem; color:#52606d;">{{ book.location }}</div>
+                            </div>
+                        </article>
+                    {% endfor %}
+                </div>
+            {% else %}
+                <p style="color:#52606d;">No active listings matched yet. Try refining your prompt or <a href="{% url 'books:book-list' %}">browse all books</a>.</p>
+            {% endif %}
+            {% if search_url %}
+                <p style="margin-top:1.25rem;">
+                    <a class="button" href="{{ search_url }}">Open these filters in the catalogue</a>
+                </p>
+            {% endif %}
+        </div>
+    </section>
+{% endif %}
+{% endblock %}

--- a/books/templates/books/base.html
+++ b/books/templates/books/base.html
@@ -1,0 +1,187 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>{% block title %}BookSwap{% endblock %}</title>
+    <style>
+        :root {
+            color-scheme: light dark;
+            --bg: #f5f7fa;
+            --card-bg: #ffffff;
+            --border: #d9dee7;
+            --text: #1f2933;
+            --accent: #2563eb;
+            --accent-dark: #1d4ed8;
+        }
+        * { box-sizing: border-box; }
+        body {
+            margin: 0;
+            font-family: "Inter", "Segoe UI", sans-serif;
+            background: var(--bg);
+            color: var(--text);
+        }
+        a { color: var(--accent); text-decoration: none; }
+        a:hover { text-decoration: underline; }
+        header {
+            background: #ffffff;
+            border-bottom: 1px solid var(--border);
+            position: sticky;
+            top: 0;
+            z-index: 10;
+        }
+        .container {
+            max-width: 1100px;
+            margin: 0 auto;
+            padding: 0 1.25rem;
+        }
+        .nav {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            padding: 1rem 0;
+        }
+        .brand {
+            font-weight: 700;
+            font-size: 1.25rem;
+            color: var(--accent-dark);
+        }
+        nav ul {
+            list-style: none;
+            display: flex;
+            gap: 1rem;
+            margin: 0;
+            padding: 0;
+            align-items: center;
+        }
+        nav a.button, .button {
+            background: var(--accent);
+            color: #fff;
+            padding: 0.55rem 1rem;
+            border-radius: 999px;
+            display: inline-flex;
+            align-items: center;
+            gap: 0.35rem;
+            font-weight: 600;
+        }
+        nav a.button:hover, .button:hover {
+            background: var(--accent-dark);
+            text-decoration: none;
+        }
+        main {
+            padding: 2rem 0 4rem;
+        }
+        footer {
+            border-top: 1px solid var(--border);
+            text-align: center;
+            padding: 1.5rem 0;
+            background: #fff;
+            font-size: 0.9rem;
+        }
+        .messages {
+            display: flex;
+            flex-direction: column;
+            gap: 0.75rem;
+            margin: 1.5rem auto 0;
+            max-width: 1100px;
+            padding: 0 1.25rem;
+        }
+        .message {
+            padding: 0.85rem 1rem;
+            border-radius: 0.75rem;
+            border: 1px solid var(--border);
+            background: var(--card-bg);
+        }
+        .message.info { border-color: #1c64f2; background: #ebf2ff; }
+        .message.success { border-color: #16a34a; background: #ecfdf5; }
+        .message.warning { border-color: #f59e0b; background: #fff7ed; }
+        .message.error { border-color: #dc2626; background: #fef2f2; }
+        form .form-control, form textarea {
+            width: 100%;
+            border-radius: 0.65rem;
+            border: 1px solid var(--border);
+            padding: 0.6rem 0.75rem;
+            font-size: 1rem;
+        }
+        form label { font-weight: 600; display: block; margin-bottom: 0.35rem; }
+        form .form-check-input { width: auto; margin-right: 0.5rem; }
+        form .field-group { margin-bottom: 1.2rem; }
+        .form-help { font-size: 0.85rem; color: #52606d; }
+        .grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+            gap: 1.5rem;
+        }
+        .card {
+            background: var(--card-bg);
+            border: 1px solid var(--border);
+            border-radius: 1rem;
+            overflow: hidden;
+            display: flex;
+            flex-direction: column;
+            transition: transform 0.2s ease, box-shadow 0.2s ease;
+        }
+        .card:hover { transform: translateY(-4px); box-shadow: 0 12px 24px rgba(15, 23, 42, 0.08); }
+        .card img {
+            width: 100%;
+            aspect-ratio: 3 / 4;
+            object-fit: cover;
+        }
+        .card-body { padding: 1rem 1.1rem 1.5rem; display: flex; flex-direction: column; gap: 0.6rem; }
+        .card-title { font-size: 1.1rem; margin: 0; }
+        .empty-state {
+            text-align: center;
+            padding: 3rem 1rem;
+            background: var(--card-bg);
+            border-radius: 1rem;
+            border: 1px dashed var(--border);
+        }
+        .breadcrumbs { font-size: 0.95rem; margin-bottom: 1rem; color: #52606d; }
+        .section-title { font-size: 1.8rem; margin-bottom: 1rem; }
+        @media (max-width: 640px) {
+            nav ul { flex-wrap: wrap; gap: 0.75rem; }
+            header { position: static; }
+        }
+    </style>
+</head>
+<body>
+<header>
+    <div class="container nav">
+        <a class="brand" href="{% url 'books:book-list' %}">BookSwap</a>
+        <nav>
+            <ul>
+                <li><a href="{% url 'books:book-list' %}">Browse</a></li>
+                <li><a href="{% url 'books:ai-advice' %}">AI advice</a></li>
+                {% if request.user.is_authenticated %}
+                    <li><a class="button" href="{% url 'books:book-create' %}">+ New listing</a></li>
+                    <li><a href="{% url 'logout' %}">Sign out</a></li>
+                {% else %}
+                    <li><a href="{% url 'login' %}">Sign in</a></li>
+                    <li><a class="button" href="{% url 'signup' %}">Join now</a></li>
+                {% endif %}
+            </ul>
+        </nav>
+    </div>
+</header>
+
+{% if messages %}
+    <div class="messages">
+        {% for message in messages %}
+            <div class="message {{ message.tags }}">{{ message }}</div>
+        {% endfor %}
+    </div>
+{% endif %}
+
+<main>
+    <div class="container">
+        {% block content %}{% endblock %}
+    </div>
+</main>
+
+<footer>
+    <div class="container">
+        Built with Django templates for effortless book sharing.
+    </div>
+</footer>
+</body>
+</html>

--- a/books/templates/books/book_confirm_delete.html
+++ b/books/templates/books/book_confirm_delete.html
@@ -1,0 +1,18 @@
+{% extends "books/base.html" %}
+
+{% block title %}Delete {{ object.title }} · BookSwap{% endblock %}
+
+{% block content %}
+<div class="breadcrumbs"><a href="{% url 'books:book-detail' object.pk %}">← Back to detail</a></div>
+<div class="card" style="padding: 2rem; max-width: 640px; margin: 0 auto; text-align: center;">
+    <h1 class="section-title">Remove this listing?</h1>
+    <p style="color:#52606d; margin-bottom: 2rem;">This action cannot be undone. Other readers will no longer see <strong>{{ object.title }}</strong> in the catalogue.</p>
+    <form method="post">
+        {% csrf_token %}
+        <div style="display:flex; gap:0.75rem; justify-content:center;">
+            <button type="submit" class="button" style="background:#ef4444;">Yes, delete it</button>
+            <a class="button" style="background:#9ca3af;" href="{% url 'books:book-detail' object.pk %}">Cancel</a>
+        </div>
+    </form>
+</div>
+{% endblock %}

--- a/books/templates/books/book_detail.html
+++ b/books/templates/books/book_detail.html
@@ -1,0 +1,42 @@
+{% extends "books/base.html" %}
+
+{% block title %}{{ book.title }} · BookSwap{% endblock %}
+
+{% block content %}
+<div class="breadcrumbs"><a href="{% url 'books:book-list' %}">← Back to listings</a></div>
+<div class="card" style="padding: 1.5rem; display: grid; gap: 1.5rem; grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));">
+    <div>
+        {% if book.image %}
+            <img src="{{ book.image.url }}" alt="{{ book.title }} cover" style="width:100%; border-radius: 1rem; border:1px solid var(--border);">
+        {% else %}
+            <img src="https://placehold.co/600x800?text=No+image" alt="No cover available" style="width:100%; border-radius: 1rem; border:1px solid var(--border);">
+        {% endif %}
+    </div>
+    <div>
+        <h1 style="font-size: 2rem; margin-top:0;">{{ book.title }}</h1>
+        {% if book.author %}
+            <p style="color:#52606d; margin-top:0.25rem;">by {{ book.author }}</p>
+        {% endif %}
+        <p style="margin-top: 0.5rem; font-size:1.05rem; line-height:1.6;">{{ book.description|linebreaks }}</p>
+        <dl style="display:grid; grid-template-columns:max-content 1fr; gap:0.4rem 1rem; margin-top:1.5rem;">
+            <dt style="font-weight:600;">Owner</dt>
+            <dd>{{ book.owner.username }}</dd>
+            {% if book.phone_number %}
+                <dt style="font-weight:600;">Phone</dt>
+                <dd><a href="tel:{{ book.phone_number }}">{{ book.phone_number }}</a></dd>
+            {% endif %}
+            <dt style="font-weight:600;">Location</dt>
+            <dd>{{ book.location }}</dd>
+            <dt style="font-weight:600;">Listed</dt>
+            <dd>{{ book.created_at|date:"F j, Y" }}</dd>
+        </dl>
+        <div style="margin-top:1.5rem; display:flex; gap:0.75rem; flex-wrap:wrap;">
+            <a class="button" href="{% url 'books:ai-advice' %}">Need recommendations?</a>
+            {% if is_owner %}
+                <a class="button" href="{% url 'books:book-update' book.pk %}">Edit listing</a>
+                <a class="button" style="background:#ef4444;" href="{% url 'books:book-delete' book.pk %}">Delete</a>
+            {% endif %}
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/books/templates/books/book_form.html
+++ b/books/templates/books/book_form.html
@@ -1,0 +1,29 @@
+{% extends "books/base.html" %}
+
+{% block title %}{% if object %}Edit {{ object.title }}{% else %}Create listing{% endif %} · BookSwap{% endblock %}
+
+{% block content %}
+<div class="breadcrumbs"><a href="{% url 'books:book-list' %}">← Back to listings</a></div>
+<div class="card" style="padding: 1.75rem; max-width: 760px; margin: 0 auto;">
+    <h1 class="section-title" style="margin-bottom: 0.5rem;">{% if object %}Edit listing{% else %}Create a book listing{% endif %}</h1>
+    <p style="color:#52606d; margin-bottom: 2rem;">Share key details so readers know what makes this book special.</p>
+    <form method="post" enctype="multipart/form-data" novalidate>
+        {% csrf_token %}
+        {{ form.non_field_errors }}
+        {% for field in form %}
+            <div class="field-group">
+                <label for="id_{{ field.name }}">{{ field.label }}{% if field.field.required %} *{% endif %}</label>
+                {{ field }}
+                {% if field.help_text %}<div class="form-help">{{ field.help_text }}</div>{% endif %}
+                {% for error in field.errors %}
+                    <div style="color:#dc2626; font-size:0.9rem;">{{ error }}</div>
+                {% endfor %}
+            </div>
+        {% endfor %}
+        <div style="display:flex; gap:0.75rem;">
+            <button type="submit" class="button">{% if object %}Save changes{% else %}Publish listing{% endif %}</button>
+            <a class="button" style="background:#9ca3af;" href="{% if object %}{% url 'books:book-detail' object.pk %}{% else %}{% url 'books:book-list' %}{% endif %}">Cancel</a>
+        </div>
+    </form>
+</div>
+{% endblock %}

--- a/books/templates/books/book_list.html
+++ b/books/templates/books/book_list.html
@@ -1,0 +1,80 @@
+{% extends "books/base.html" %}
+
+{% block title %}Browse books · BookSwap{% endblock %}
+
+{% block content %}
+<section>
+    <h1 class="section-title">Find your next read</h1>
+    <p style="max-width: 620px; color: #52606d; margin-bottom: 1.5rem;">
+        Search by keyword, author or title. Add your books to connect with readers who would love them next.
+    </p>
+    <form method="get" class="card" style="padding: 1.25rem 1.5rem; margin-bottom: 2rem;">
+        <div class="field-group">
+            {{ search_form.query.label_tag }}
+            {{ search_form.query }}
+        </div>
+        <div class="field-group" style="display: grid; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); gap: 1rem;">
+            <div>
+                {{ search_form.titles.label_tag }}
+                {{ search_form.titles }}
+                <div class="form-help">{{ search_form.titles.help_text }}</div>
+            </div>
+            <div>
+                {{ search_form.authors.label_tag }}
+                {{ search_form.authors }}
+                <div class="form-help">{{ search_form.authors.help_text }}</div>
+            </div>
+        </div>
+        <div style="display: flex; gap: 0.75rem; flex-wrap: wrap;">
+            <button type="submit" class="button">Search</button>
+            {% if has_filters %}
+                <a class="button" style="background: #9ca3af;" href="{% url 'books:book-list' %}">Clear filters</a>
+            {% endif %}
+        </div>
+    </form>
+</section>
+
+{% if books %}
+    <div class="grid">
+        {% for book in books %}
+            <article class="card">
+                {% if book.image %}
+                    <img src="{{ book.image.url }}" alt="{{ book.title }} cover">
+                {% else %}
+                    <img src="https://placehold.co/400x520?text=No+image" alt="No cover available">
+                {% endif %}
+                <div class="card-body">
+                    <h2 class="card-title"><a href="{% url 'books:book-detail' book.pk %}">{{ book.title }}</a></h2>
+                    {% if book.author %}<div style="color:#52606d;">by {{ book.author }}</div>{% endif %}
+                    <div style="font-size:0.95rem; color:#52606d;">{{ book.location }}</div>
+                    <p style="flex:1; color:#334155;">{{ book.description|truncatechars:120 }}</p>
+                    <a class="button" style="align-self:flex-start;" href="{% url 'books:book-detail' book.pk %}">View details</a>
+                </div>
+            </article>
+        {% endfor %}
+    </div>
+{% else %}
+    <div class="empty-state">
+        <h2>No listings yet</h2>
+        <p>
+            {% if has_filters %}
+                We couldn't find any books that match your filters. Try adjusting your search.
+            {% else %}
+                Be the first to share a book! Sign in and add a listing to start the exchange.
+            {% endif %}
+        </p>
+    </div>
+{% endif %}
+
+{% if is_paginated %}
+    <nav aria-label="Pagination" style="margin-top: 2rem; display:flex; justify-content:center; gap:0.5rem;">
+        {% if page_obj.has_previous %}
+            <a class="button" style="background:#e2e8f0; color:#1f2933;" href="?{% if query_string %}{{ query_string }}&amp;{% endif %}page={{ page_obj.previous_page_number }}">Previous</a>
+        {% endif %}
+        <span style="align-self:center; font-weight:600;">Page {{ page_obj.number }} of {{ page_obj.paginator.num_pages }}</span>
+        {% if page_obj.has_next %}
+            <a class="button" style="background:#e2e8f0; color:#1f2933;" href="?{% if query_string %}{{ query_string }}&amp;{% endif %}page={{ page_obj.next_page_number }}">Next</a>
+        {% endif %}
+    </nav>
+{% endif %}
+{% endblock %}

--- a/books/templates/registration/login.html
+++ b/books/templates/registration/login.html
@@ -1,0 +1,24 @@
+{% extends "books/base.html" %}
+
+{% block title %}Sign in · BookSwap{% endblock %}
+
+{% block content %}
+<div class="card" style="padding: 1.75rem; max-width: 520px; margin: 0 auto;">
+    <h1 class="section-title" style="margin-bottom: 1rem;">Welcome back</h1>
+    <form method="post" novalidate>
+        {% csrf_token %}
+        {{ form.non_field_errors }}
+        {% for field in form %}
+            <div class="field-group">
+                <label for="id_{{ field.name }}">{{ field.label }}</label>
+                {{ field }}
+                {% for error in field.errors %}
+                    <div style="color:#dc2626; font-size:0.9rem;">{{ error }}</div>
+                {% endfor %}
+            </div>
+        {% endfor %}
+        <button type="submit" class="button">Sign in</button>
+    </form>
+    <p style="margin-top:1.5rem; color:#52606d;">Don't have an account yet? <a href="{% url 'signup' %}">Create one now</a>.</p>
+</div>
+{% endblock %}

--- a/books/templates/registration/signup.html
+++ b/books/templates/registration/signup.html
@@ -1,0 +1,26 @@
+{% extends "books/base.html" %}
+
+{% block title %}Create account · BookSwap{% endblock %}
+
+{% block content %}
+<div class="card" style="padding: 1.75rem; max-width: 520px; margin: 0 auto;">
+    <h1 class="section-title" style="margin-bottom: 1rem;">Join BookSwap</h1>
+    <p style="color:#52606d;">Share your books and discover new reads from the community.</p>
+    <form method="post" novalidate style="margin-top:1.5rem;">
+        {% csrf_token %}
+        {{ form.non_field_errors }}
+        {% for field in form %}
+            <div class="field-group">
+                <label for="id_{{ field.name }}">{{ field.label }}</label>
+                {{ field }}
+                {% if field.help_text %}<div class="form-help">{{ field.help_text }}</div>{% endif %}
+                {% for error in field.errors %}
+                    <div style="color:#dc2626; font-size:0.9rem;">{{ error }}</div>
+                {% endfor %}
+            </div>
+        {% endfor %}
+        <button type="submit" class="button">Create account</button>
+    </form>
+    <p style="margin-top:1.5rem; color:#52606d;">Already have an account? <a href="{% url 'login' %}">Sign in</a>.</p>
+</div>
+{% endblock %}

--- a/books/urls.py
+++ b/books/urls.py
@@ -1,12 +1,22 @@
 
-from django.urls import path, include
-from rest_framework.routers import DefaultRouter
-from .views import BookViewSet, AIAdviceView
+from django.urls import path
 
-router = DefaultRouter()
-router.register(r"books", BookViewSet, basename="book")
+from .views import (
+    BookListView,
+    BookDetailView,
+    BookCreateView,
+    BookUpdateView,
+    BookDeleteView,
+    AIAdviceView,
+)
+
+app_name = "books"
 
 urlpatterns = [
-    path("", include(router.urls)),
-    path("ai/books/advice/", AIAdviceView.as_view(), name="ai-books-advice"),
+    path("", BookListView.as_view(), name="book-list"),
+    path("books/create/", BookCreateView.as_view(), name="book-create"),
+    path("books/<int:pk>/", BookDetailView.as_view(), name="book-detail"),
+    path("books/<int:pk>/edit/", BookUpdateView.as_view(), name="book-update"),
+    path("books/<int:pk>/delete/", BookDeleteView.as_view(), name="book-delete"),
+    path("ai-advice/", AIAdviceView.as_view(), name="ai-advice"),
 ]

--- a/bookx/settings.py
+++ b/bookx/settings.py
@@ -25,18 +25,11 @@ INSTALLED_APPS = [
     "django.contrib.messages",
     "django.contrib.staticfiles",
 
-    # 3rd party
-    "rest_framework",
-    "rest_framework.authtoken",
-    "drf_spectacular",
-    "corsheaders",
-
     # Local apps
     "books",
 ]
 
 MIDDLEWARE = [
-    "corsheaders.middleware.CorsMiddleware",
     "django.middleware.security.SecurityMiddleware",
     "whitenoise.middleware.WhiteNoiseMiddleware",   # serve static files
     "django.contrib.sessions.middleware.SessionMiddleware",
@@ -116,47 +109,17 @@ if os.getenv("AWS_STORAGE_BUCKET_NAME"):
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 
 # --------------------------------------------------------------------------------------
-# DRF / Auth
+# Authentication redirects
 # --------------------------------------------------------------------------------------
-REST_FRAMEWORK = {
-    "DEFAULT_AUTHENTICATION_CLASSES": (
-        "rest_framework_simplejwt.authentication.JWTAuthentication",
-    ),
-    "DEFAULT_PERMISSION_CLASSES": (
-        "rest_framework.permissions.IsAuthenticatedOrReadOnly",
-    ),
-    "DEFAULT_SCHEMA_CLASS": "drf_spectacular.openapi.AutoSchema",
-    "DEFAULT_PARSER_CLASSES": (
-        "rest_framework.parsers.JSONParser",
-        "rest_framework.parsers.FormParser",
-        "rest_framework.parsers.MultiPartParser",
-    ),
-}
+LOGIN_REDIRECT_URL = "books:book-list"
+LOGOUT_REDIRECT_URL = "books:book-list"
 
-SPECTACULAR_SETTINGS = {
-    "TITLE": "BookX API",
-    "DESCRIPTION": "Book exchange + AI advisor (v4, hardened)",
-    "VERSION": "4.0.0",
-    "SERVE_INCLUDE_SCHEMA": False,
-    "COMPONENT_SPLIT_REQUEST": True,
-    "SWAGGER_UI_SETTINGS": {"persistAuthorization": True},
-}
-
-# --------------------------------------------------------------------------------------
-# CORS / CSRF
-# - CORS for ALL (as requested)
-# - CSRF trusted for Railway + optional frontend domain(s)
-# --------------------------------------------------------------------------------------
-CORS_ALLOW_ALL_ORIGINS = True
-CORS_ALLOW_CREDENTIALS = True  # if you need cookies across origins
-
-# Comma-separated list of extra trusted origins from env, e.g. "https://yourdomain.com,https://www.yourdomain.com"
+# Allow configuring trusted hosts for CSRF when deployed behind HTTPS
 _extra_csrf = [o.strip() for o in os.getenv("CSRF_EXTRA_TRUSTED", "").split(",") if o.strip()]
 CSRF_TRUSTED_ORIGINS = [
     "https://*.up.railway.app",
     "https://railway.app",
-    # add your custom domains here or via CSRF_EXTRA_TRUSTED env
-    *[o for o in _extra_csrf],
+    *_extra_csrf,
 ]
 
 # --------------------------------------------------------------------------------------

--- a/bookx/urls.py
+++ b/bookx/urls.py
@@ -1,19 +1,15 @@
 
 from django.contrib import admin
-from django.urls import path, include
+from django.urls import include, path
 from django.conf import settings
 from django.conf.urls.static import static
-from drf_spectacular.views import SpectacularAPIView, SpectacularSwaggerView
-from rest_framework_simplejwt.views import TokenObtainPairView, TokenRefreshView
 
-from books.views import HealthView
+from books.views import SignUpView, BookSwapLoginView
 
 urlpatterns = [
     path("admin/", admin.site.urls),
-    path("api/health/", HealthView.as_view(), name="health"),
-    path("api/auth/token/", TokenObtainPairView.as_view(), name="token_obtain_pair"),
-    path("api/auth/token/refresh/", TokenRefreshView.as_view(), name="token_refresh"),
-    path("api/schema/", SpectacularAPIView.as_view(), name="schema"),
-    path("api/docs/", SpectacularSwaggerView.as_view(url_name="schema"), name="swagger-ui"),
-    path("api/", include("books.urls")),
+    path("accounts/login/", BookSwapLoginView.as_view(), name="login"),
+    path("accounts/signup/", SignUpView.as_view(), name="signup"),
+    path("accounts/", include("django.contrib.auth.urls")),
+    path("", include("books.urls")),
 ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,11 +8,7 @@ certifi==2025.8.3
 charset-normalizer==3.4.3
 dj-database-url==3.0.1
 Django==5.0.7
-django-cors-headers==4.4.0
 django-storages==1.14.6
-djangorestframework==3.15.2
-djangorestframework-simplejwt==5.3.1
-drf-spectacular==0.27.2
 google-auth==2.40.3
 google-genai==0.3.0
 gunicorn==23.0.0


### PR DESCRIPTION
## Summary
- replace the DRF API with Django class-based views and forms that power listings, account creation, and AI assistance flows
- build a full set of templates for browsing, managing books, authentication, and AI advice using Django's templating engine
- simplify settings, URLs, and dependencies to remove REST-specific tooling and keep the project deployment-ready for form-based pages

## Testing
- python manage.py check
- python manage.py test

------
https://chatgpt.com/codex/tasks/task_e_68cfb1e1c868832abf46fef525cf1214